### PR TITLE
Added $arguments = null to filter's before and after methods.

### DIFF
--- a/Views/Filter/Filter.php
+++ b/Views/Filter/Filter.php
@@ -20,7 +20,7 @@ class {! name !} implements FilterInterface
 	 *
 	 * @return mixed
 	 */
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		//
 	}
@@ -35,7 +35,7 @@ class {! name !} implements FilterInterface
 	 *
 	 * @return mixed
 	 */
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 		//
 	}


### PR DESCRIPTION
Since version 4.0.4, FilterInterface before and after methods have $arguments parameter. Boilerplate filter class must implement this change.